### PR TITLE
优化阿里大于短信参数配置 (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ $easySms->send(13188888888, $message);
 ```php
     'alidayu' => [
         'app_key' => '',
+        'app_secret' => '',
         'sign_name' => '',
     ],
 ```
@@ -267,6 +268,7 @@ $easySms->send(13188888888, $message);
         'ak' => '',
         'sk' => '',
         'invoke_id' => '',
+        'domain' => '',
     ],
 ```
 

--- a/src/Gateways/BaiduGateway.php
+++ b/src/Gateways/BaiduGateway.php
@@ -57,8 +57,8 @@ class BaiduGateway extends Gateway
             'x-bce-date' => $datetime,
             'x-bce-content-sha256' => hash('sha256', json_encode($params)),
         ];
-
-        $signHeaders = $this->getHeadersToSign($headers, ['host', 'x-bce-content-sha256']); // 获得需要签名的数据
+        //获得需要签名的数据
+        $signHeaders = $this->getHeadersToSign($headers, ['host', 'x-bce-content-sha256']);
 
         $headers['Authorization'] = $this->generateSign($signHeaders, $datetime, $config);
 


### PR DESCRIPTION
* 精简过滤签名getHeadersToSign的方法，headers确定，指定的keys确定，兼容写法可以全部删除。
精简getCanonicalHeaders方法，无空值，兼容代码删除

Signed-off-by: iwzh <wzhec@foxmail.com>

* 优化readme.md 阿里大于配置参数。

Signed-off-by: iwzh <wzhec@foxmail.com>